### PR TITLE
Add Swagger for API documentation & SLF4J logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
 			<version>1.5.5.Final</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.6.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/ai/zomind/testcasemanagement/config/SwaggerConfig.java
+++ b/src/main/java/ai/zomind/testcasemanagement/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package ai.zomind.testcasemanagement.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Test Case Management API")
+                        .version("1.0")
+                        .description("API documentation for the Test Case Management application"));
+    }
+}

--- a/src/main/java/ai/zomind/testcasemanagement/controller/TestCaseController.java
+++ b/src/main/java/ai/zomind/testcasemanagement/controller/TestCaseController.java
@@ -3,6 +3,7 @@ package ai.zomind.testcasemanagement.controller;
 import ai.zomind.testcasemanagement.dto.TestCaseRequestDto;
 import ai.zomind.testcasemanagement.dto.TestCaseResponseDto;
 import ai.zomind.testcasemanagement.service.TestCaseService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -26,6 +27,7 @@ public class TestCaseController {
     private TestCaseService testCaseService;
 
     @GetMapping
+    @Operation(summary = "Get all test cases, also filter by status and priority optionally")
     public Page<TestCaseResponseDto> getTestCases(
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String priority,
@@ -36,23 +38,27 @@ public class TestCaseController {
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Get test case by id")
     public ResponseEntity<TestCaseResponseDto> getTestCaseById(@PathVariable String id) {
         TestCaseResponseDto testCaseResponseDto = testCaseService.getTestCaseById(id);
         return ResponseEntity.ok(testCaseResponseDto);
     }
 
     @PostMapping
+    @Operation(summary = "Create a new test case")
     public ResponseEntity<TestCaseResponseDto> createTestCase(@RequestBody @Valid TestCaseRequestDto testCaseRequestDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(testCaseService.createTestCase(testCaseRequestDto));
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "Update test case by id")
     public ResponseEntity<TestCaseResponseDto> updateTestCase(@PathVariable String id, @RequestBody TestCaseRequestDto testCaseRequestDto) {
         TestCaseResponseDto testCaseResponseDto = testCaseService.updateTestCase(id, testCaseRequestDto);
         return ResponseEntity.ok(testCaseResponseDto);
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "Delete test case by id")
     public ResponseEntity<TestCaseResponseDto> deleteTestCase(@PathVariable String id) {
         return ResponseEntity.ok(testCaseService.deleteTestCase(id));
     }

--- a/src/main/java/ai/zomind/testcasemanagement/dto/TestCaseRequestDto.java
+++ b/src/main/java/ai/zomind/testcasemanagement/dto/TestCaseRequestDto.java
@@ -1,5 +1,6 @@
 package ai.zomind.testcasemanagement.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -10,13 +11,17 @@ public class TestCaseRequestDto {
 
     @NotNull(message = "Title cannot be null")
     @NotBlank(message = "Title cannot be blank")
+    @Schema(description = "Title of the test case", example = "Login Test")
     private String title;
 
+    @Schema(description = "Description of the test case", example = "This test case verifies the login functionality.")
     private String description;
 
     @Pattern(regexp = "PENDING|IN_PROGRESS|PASSED|FAILED", message = "Invalid status. Allowed values: PENDING, IN_PROGRESS, PASSED, FAILED")
+    @Schema(description = "Status of the test case", example = "IN_PROGRESS")
     private String status;
 
     @Pattern(regexp = "LOW|MEDIUM|HIGH", message = "Invalid priority. Allowed values: LOW, MEDIUM, HIGH")
+    @Schema(description = "Priority of the test case", example = "HIGH")
     private String priority;
 }

--- a/src/main/java/ai/zomind/testcasemanagement/exceptionhandler/GlobalExceptionHandler.java
+++ b/src/main/java/ai/zomind/testcasemanagement/exceptionhandler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package ai.zomind.testcasemanagement.exceptionhandler;
 import ai.zomind.testcasemanagement.exception.InvalidDataException;
 import ai.zomind.testcasemanagement.exception.ResourceNotFoundException;
 import ai.zomind.testcasemanagement.exception.errormessage.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -24,6 +26,8 @@ public class GlobalExceptionHandler {
         String errorMessage = fieldErrors.stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .collect(Collectors.joining(" | "));
+
+        log.error("Filed validation error. Enter valid input");
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
                 .body(ApiErrorResponse
@@ -36,6 +40,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ApiErrorResponse> handleResourceNotFoundException(ResourceNotFoundException ex) {
+        log.error("Resource not found. Check entered id");
         return ResponseEntity.status(HttpStatus.NOT_FOUND.value())
                 .body(ApiErrorResponse
                     .builder()
@@ -47,6 +52,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidDataException.class)
     public ResponseEntity<ApiErrorResponse> handleInvalidDataException(InvalidDataException ex) {
+        log.error("Invalid data. Enter the valid input only");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
                 .body(ApiErrorResponse
                         .builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,7 @@ spring:
     mongodb:
       uri: mongodb://localhost:27017/testcase_db
       auto-index-creation: true
+
+springdoc:
+  swagger-ui:
+    path: /docs.html


### PR DESCRIPTION
### **Description:**  
This PR introduces **Swagger** for API documentation and integrates **SLF4J** logging for important events in the application.  

### **Changes Introduced:**  
✅ **Swagger Integration:**  
- Added `springdoc-openapi-starter-webmvc-ui` dependency in `pom.xml`.  
- Configured Swagger UI to document and visualize REST APIs.  
- Swagger is accessible at: `/docs.html`

✅ **SLF4J Logging:**  
- Integrated SLF4J with `@Slf4j` annotation for logging critical events.  
- Added log statements in services.
- Improved error handling with structured logging.  
